### PR TITLE
feat: add forum with ruby 3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-mfe.git@$VERSION#egg=tutor-mfe
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
           "
       # Backup
       - name: Backup data
@@ -75,7 +76,7 @@ jobs:
           "
       # Configure
       - name: Enable plugins
-        run: $SSH "$TUTOR plugins enable mfe indigo android"
+        run: $SSH "$TUTOR plugins enable mfe indigo android forum"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e


### PR DESCRIPTION
  This just adds the forum from its olive PR. Below how I test  this:

  1- while on venv of the tutor olive (and while tutor was already running)
  2- export VERSION=olive
  3- pip install --upgrade --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
  4- tutor plugins enable forum
  5- tutor config save
  6- tutor images build forum
  7- tutor local init --limit=forum
  8- tutor local start forum -d
  7- reboot lms/cms and start adding comments on a course
  
  This PR realtes to overhangio/tutor-forum#11 and openedx/cs_comments_service/pull/392 