### PR TITLE
feat: install and enable notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
           "
       # Backup
       - name: Backup data
@@ -76,7 +77,7 @@ jobs:
           "
       # Configure
       - name: Enable plugins
-        run: $SSH "$TUTOR plugins enable mfe indigo android forum"
+        run: $SSH "$TUTOR plugins enable mfe indigo android forum notes"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e


### PR DESCRIPTION
# Description
The PR enables https://github.com/overhangio/tutor-notes/tree/olive plugin.
Installed and tested locally:
```
git clone -b olive git@github.com:overhangio/tutor-notes.git
pip install -e tutor-notes
tutor plugins enable notes && tutor config save
tutor local launch
```

Then enable Student Notes in Advanced Settings and test in LMS.
![image](https://user-images.githubusercontent.com/877401/198248598-f4dc1d8d-f328-428e-adb6-2150dc3ed1cd.png)

---
# Notes:
- probably will rebase after #21 