### PR TITLE
chore: enable event routing backends plugin on olive demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,8 +88,11 @@ jobs:
               --set ENABLE_HTTPS=true \
               --set PLATFORM_NAME='Open edx $VERSION Demo'
           "
-      # - name: Install extra xblocks/packages
-      #   run: |
+      - name: Install extra xblocks/packages
+        run: |
+          $SSH "#! /bin/bash -e
+            $TUTOR config save --set 'OPENEDX_EXTRA_PIP_REQUIREMENTS=[\"edx-event-routing-backends>=5.2.1,<6.0.0\"]'
+          "
       #     $SSH "#! /bin/bash -e
       #       $TUTOR config save --set 'OPENEDX_EXTRA_PIP_REQUIREMENTS=[\"openedx-scorm-xblock<15.0.0,>=14.0.0\", \"git+https://github.com/ubc/ubcpi@757e8903395c749dc8bd9decc314377fd63d0e5b\", \"edx-event-routing-backends>=5.2.0,<6.0.0\"]'
           # "


### PR DESCRIPTION
PR has changes to enable event routing backends plugin on olive demo.