### PR TITLE
feat: install and enable tutor xqueue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
           "
       # Backup
       - name: Backup data
@@ -80,7 +81,7 @@ jobs:
           "
       # Configure
       - name: Enable plugins
-        run: $SSH "$TUTOR plugins enable mfe indigo android forum notes codejail discovery ecommerce"
+        run: $SSH "$TUTOR plugins enable mfe indigo android forum notes codejail discovery ecommerce xqueue"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e
@@ -98,9 +99,9 @@ jobs:
       #     $SSH "#! /bin/bash -e
       #       $TUTOR config save --set 'OPENEDX_EXTRA_PIP_REQUIREMENTS=[\"openedx-scorm-xblock<15.0.0,>=14.0.0\", \"git+https://github.com/ubc/ubcpi@757e8903395c749dc8bd9decc314377fd63d0e5b\", \"edx-event-routing-backends>=5.2.0,<6.0.0\"]'
           # "
-      # - name: Configure xqueue grader password
-      #   run: |
-      #     $SSH "$TUTOR config save --set XQUEUE_AUTH_PASSWORD=xqueuepassword"
+      - name: Configure xqueue grader password
+        run: |
+          $SSH "$TUTOR config save --set XQUEUE_AUTH_PASSWORD=xqueuepassword"
       # Build
       - name: Build Docker images
         run: |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following plugins are enabled on the demo platform:
 - tutor-android ([PR](https://github.com/overhangio/tutor-android/pull/5) by @regisb): app can be downloaded from https://mobile.olive.demo.overhang.io/app.apk.
 - tutor-forum ([PR](https://github.com/overhangio/tutor-forum/pull/11) by @ghassanmas)
 - tutor-notes ([PR](https://github.com/overhangio/tutor-notes/pull/18) by @jfavellar90)
+- tutor-xqueue ([PR](https://github.com/overhangio/tutor-xqueue/pull/13) by @jfavellar90)
 - tutor-contrib-codejail ([PR](https://github.com/eduNEXT/tutor-contrib-codejail/pull/28) by @mariajgrimaldi)
 - tutor-discovery ([PR](https://github.com/overhangio/tutor-discovery/pull/36) by @regisb)
 - tutor-ecommerce ([PR](https://github.com/overhangio/tutor-ecommerce/pull/35) by @regisb): admin user can login with the credentials above at https://ecommerce.olive.demo.overhang.io/
@@ -38,7 +39,6 @@ The following plugins are enabled on the demo platform:
 The following plugins have not been installed, yet:
 
 - [tutor-minio](https://github.com/overhangio/tutor-minio/)
-- [tutor-xqueue](https://github.com/overhangio/tutor-xqueue/)
 
 If you are interested in upgrading these plugins to Olive, please submit a PR by following the regular [plugin upgrade instructions](https://discuss.overhang.io/t/how-to-upgrade-a-tutor-plugin/1488).
 


### PR DESCRIPTION
The PR enables https://github.com/overhangio/tutor-xqueue/tree/olive plugin.
Installed and tested locally:

git clone -b olive git@github.com:overhangio/tutor-xqueue.git
pip install -e tutor-xqueue
tutor plugins enable xqueue && tutor config save
tutor local launch