### PR TITLE
feat: enable forum plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-mfe.git@$VERSION#egg=tutor-mfe
             # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
             # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
-            # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
             # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
             # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
             # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
@@ -83,7 +83,7 @@ jobs:
       # Configure
       - name: Enable plugins
         # missing plugins: indigo android forum notes codejail discovery ecommerce xqueue
-        run: $SSH "$TUTOR plugins enable mfe"
+        run: $SSH "$TUTOR plugins enable mfe forum"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ The [deployment script](https://github.com/overhangio/openedx-release-demo/blob/
 The following plugins are enabled on the demo platform:
 
 - tutor-mfe ([PR](https://github.com/overhangio/tutor-mfe/pull/120) by @regisb)
+- tutor-forum ([PR])(https://github.com/overhangio/tutor-forum/pull/22 by @ghassanmas)
 
 The following plugins have not been installed, yet:
 
 - tutor-minio
 - tutor-indigo
 - tutor-android
-- tutor-forum
 - tutor-notes
 - tutor-xqueue
 - tutor-contrib-codejail


### PR DESCRIPTION
Enabling the forum/discussion plugin, simliar #20. 
- [x] Tested with tutor core plam branch 
- [x] built all images 
- [x] checked discussion MFE and was able to post 
- [ ] ARM support, not yet see this issue overhangio/tutor-forum/issues/23 _an upsteram fix in pending_ @ openedx/cs_comments_service/pull/411 