### PR TITLE
feat: enable notes and xqueue plugins

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
           "
       # Backup
       - name: Backup data
@@ -86,7 +88,7 @@ jobs:
       # Configure
       - name: Enable plugins
         # missing plugins: none
-        run: $SSH "$TUTOR plugins enable mfe forum discovery ecommerce"
+        run: $SSH "$TUTOR plugins enable mfe forum discovery ecommerce notes xqueue"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e
@@ -101,9 +103,9 @@ jobs:
       #     $SSH "#! /bin/bash -e
       #       $TUTOR config save --append 'OPENEDX_EXTRA_PIP_REQUIREMENTS=edx-event-routing-backends>=5.3.0,<6.0.0'
       #     "
-      # - name: Configure xqueue grader password
-      #   run: |
-      #     $SSH "$TUTOR config save --set XQUEUE_AUTH_PASSWORD=xqueuepassword"
+      - name: Configure xqueue grader password
+        run: |
+          $SSH "$TUTOR config save --set XQUEUE_AUTH_PASSWORD=xqueuepassword"
       # Build
       - name: Build Docker images
         run: |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The following plugins are enabled on the demo platform:
 - tutor-forum ([PR](https://github.com/overhangio/tutor-forum/pull/28) by @ghassanmas)
 - tutor-discovery ([PR](https://github.com/overhangio/tutor-discovery/pull/50) by @ziafazal)
 - tutor-ecommerce ([PR](https://github.com/overhangio/tutor-ecommerce/pull/47) by @ziafazal)
-
+- tutor-notes ([PR](https://github.com/overhangio/tutor-notes/pull/29) by @jfavellar90)
+- tutor-xqueue ([PR](https://github.com/overhangio/tutor-xqueue/pull/25) by @jfavellar90)
 
 The following plugins have not been installed, yet:
 
@@ -39,8 +40,6 @@ The following plugins have not been installed, yet:
 - [tutor-credentials](https://github.com/overhangio/tutor-credentials)
 - [tutor-indigo](https://github.com/overhangio/tutor-indigo)
 - [tutor-minio](https://github.com/overhangio/tutor-minio)
-- [tutor-notes](https://github.com/overhangio/tutor-notes)
-- [tutor-xqueue](https://github.com/overhangio/tutor-xqueue)
 - [tutor-contrib-codejail](https://github.com/eduNEXT/tutor-contrib-codejail)
 
 


### PR DESCRIPTION
This PR enables notes and xqueue plugins for the Quince demo installation