### PR TITLE
build: temporarily disable the scheduled job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,11 @@
 name: Deploy
 
 on:
-  schedule:
-    # Run at 7am every day
-    # - cron:  '0 7 * * *'
-    # Run at 7am every Monday
-    - cron:  '0 7 * * 1'
+  # schedule:
+  # Run at 7am every day
+  # - cron:  '0 7 * * *'
+  # Run at 7am every Monday
+  # - cron:  '0 7 * * 1'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Temporarily disabled the scheduled run, it will be resumed on/after May 9th, 2024, when the redwood branches are cut.