### PR TITLE
chore: keep SSH alive

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      SSH: ssh -o StrictHostKeyChecking=no -i ~/.ssh/demo.key ubuntu@redwood.demo.edly.io
+      SSH: ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=150 -i ~/.ssh/demo.key ubuntu@redwood.demo.edly.io
       VERSION: redwood
       LMS_HOST: redwood.demo.edly.io
       TUTOR: ~/.local/bin/tutor


### PR DESCRIPTION
Adding changes from https://github.com/edly-io/openedx-nightly-sandbox/pull/8, to ensure SSH connection does not break on MFE builds (and any other build/process that takes a bit of time)