### PR TITLE
chore: update cron schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     # Run at 7am every day
     # - cron:  '0 7 * * *'
-    # Run at 7am every Monday
-    - cron: "0 7 * * 1"
+    # Run at 2am every Monday
+    - cron: "0 2 * * 1"
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You may log in with the following credentials:
   - email: admin@overhang.io
   - password: admin
 
-The platform is reset weekly, every Monday at 7 am UTC.
+The platform is reset weekly, every Monday at 2 am UTC.
 
 The [deployment script](https://github.com/overhangio/openedx-release-demo/blob/master/.github/workflows/deploy.yml) is included in this repository. If you are working on testing the latest release and you would like to modify this script, please open a pull request.
 


### PR DESCRIPTION
Update the cron job schedule to run the sandbox reset at 2 AM UTC (7 AM Pakistan time). This will ensure any issues with sandbox build are captured earlier in the day and then sandbox build can be restarted earlier. On average, with max-parallelism=2, sandbox takes around 4-5 hours to complete.