### PR TITLE
chore: enable more plugins for Sumac

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,8 @@ jobs:
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor.git@$VERSION#egg=tutor
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-mfe.git@$VERSION#egg=tutor-mfe
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-credentials.git@$VERSION#egg=tutor-credentials
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-credentials.git@$VERSION#egg=tutor-credentials
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-minio.git@$VERSION#egg=tutor-minio

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,11 +107,6 @@ jobs:
               --set ENABLE_HTTPS=true \
               --set PLATFORM_NAME='Open edX Sumac Demo'
           "
-      - name: Install extra xblocks/packages
-        run: |
-          $SSH "#! /bin/bash -e
-            $TUTOR config save --append 'OPENEDX_EXTRA_PIP_REQUIREMENTS=edx-event-routing-backends>=7.2.0,<8.0.0'
-          "
 
       - name: Configure xqueue grader password
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,24 +36,23 @@ jobs:
       # apt update && apt install -y python3-pip
       - name: Install dependencies, tutor and plugins (from source)
         # Pending:
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-cairn.git@$VERSION#egg=tutor-cairn
         # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-credentials.git@$VERSION#egg=tutor-credentials
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
         # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-jupyter.git@$VERSION#egg=tutor-jupyter
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-minio.git@$VERSION#egg=tutor-minio
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
         # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-webui.git@$VERSION#egg=tutor-webui
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/openedx/tutor-contrib-aspects.git@master#egg=tutor-contrib-aspects
-        # pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
         run: |
           $SSH "#! /bin/bash -e
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor.git@$VERSION#egg=tutor
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-mfe.git@$VERSION#egg=tutor-mfe
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-credentials.git@$VERSION#egg=tutor-credentials
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
             pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-minio.git@$VERSION#egg=tutor-minio
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/openedx/tutor-contrib-aspects.git@v1.2.0#egg=tutor-contrib-aspects
+            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
           "
       # Backup
       - name: Backup data
@@ -97,8 +96,8 @@ jobs:
           "
       # Configure
       - name: Enable plugins
-        # missing plugins: cairn android aspects credentials discovery ecommerce forum jupyter minio notes webui xqueue codejail
-        run: $SSH "$TUTOR plugins enable indigo mfe forum"
+        # missing plugins: android jupyter webui  
+        run: $SSH "$TUTOR plugins enable indigo mfe aspects codejail credentials discovery ecommerce forum minio notes xqueue "
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e
@@ -113,10 +112,10 @@ jobs:
           $SSH "#! /bin/bash -e
             $TUTOR config save --append 'OPENEDX_EXTRA_PIP_REQUIREMENTS=edx-event-routing-backends>=7.2.0,<8.0.0'
           "
-      # TODO: uncomment when enabling tutor-xqueue
-      # - name: Configure xqueue grader password
-      #   run: |
-      #     $SSH "$TUTOR config save --set XQUEUE_AUTH_PASSWORD=xqueuepassword"
+
+      - name: Configure xqueue grader password
+        run: |
+          $SSH "$TUTOR config save --set XQUEUE_AUTH_PASSWORD=xqueuepassword"
       # TODO: uncomment when enabling tutor-jupyter
       # - name: Configure Jupyter LTI Password
       #   run: |
@@ -128,9 +127,13 @@ jobs:
             $TUTOR images build all
           "
 
-      # TODO: uncomment when enabling tutor-contrib-codejail
-      # - name: Initialize codejail
-      #   run: $SSH "$TUTOR local do init --limit=codejail"
+      - name: Initialize codejail
+        run: $SSH "$TUTOR local do init --limit=codejail"
+      
+      - name: Configure Aspects
+        run: |
+          $SSH "$TUTOR config save --set ASPECTS_ENABLE_PII=true"
+
       - name: Launch
         run: $SSH "$TUTOR local launch --non-interactive"
       # Provision

--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ The following plugins are enabled on the demo platform:
 - tutor-android (TBA)
   - ~~The mobile apk can be downloaded from https://mobile.sumac.demo.edly.io/app.apk.~~
 - ~~tutor-cairn (TBA)~~
-  - tutor-contrib-aspects ([master branch](https://github.com/openedx/tutor-contrib-aspects/tree/master)) -- **To be enabled**
+  - tutor-contrib-aspects ([v1.2.0](https://github.com/openedx/tutor-contrib-aspects/tree/v1.2.0))
   - aspects has been enabled in place of cairn for testing of certain Product features.
-- tutor-contrib-codejail (TBA)
-- tutor-credentials (TBA)
-- tutor-discovery (TBA)
-- tutor-ecommerce (TBA)
+- tutor-contrib-codejail ([PR](https://github.com/eduNEXT/tutor-contrib-codejail/pull/59) by @MoisesGSalas)
+- tutor-credentials ([PR](https://github.com/overhangio/tutor-credentials/pull/49) by @Faraz32123)
+- tutor-discovery ([PR](https://github.com/overhangio/tutor-discovery/pull/87) by @Faraz32123)
+- tutor-ecommerce ([PR](https://github.com/overhangio/tutor-ecommerce/pull/84) by @Faraz32123)
 - tutor-forum ([PR](https://github.com/overhangio/tutor-forum/pull/49) by @ghassanmas)
 - tutor-indigo ([PR](https://github.com/overhangio/tutor-indigo/pull/101) by @hinakhadim)
 - tutor-mfe ([PR](https://github.com/overhangio/tutor-mfe/pull/227) by @hinakhadim and @DawoudSheraz)
-- tutor-minio (TBA)
-- tutor-notes (TBA)
+- tutor-minio ([PR](https://github.com/overhangio/tutor-minio/pull/51) by @Faraz32123)
+- tutor-notes ([PR](https://github.com/overhangio/tutor-notes/pull/41) by @jfavellar90)
 - tutor-webui (TBA)
-- tutor-xqueue (TBA)
+- tutor-xqueue ([PR](https://github.com/overhangio/tutor-xqueue/pull/34) by @jfavellar90)
 - tutor-jupyter (TBA)
   - LTI passport is `jupyterhub:openedx:jupyter-lti-password`.
 


### PR DESCRIPTION
### Description

- Add a step in GA to enable PII in aspects
- Enable the following plugins
  - credentials
  - discovery
  - ecommerce
  - minio
  - xqueue
  - notes
  - contrib-codejail
  - contrib-aspects (v1.2.0)
- Remove edx-event-routing-backend installation as it is now installed within aspects. It is currently only used in contrib-aspects, so it does not need to be installed explicitly.