### PR TITLE
feat: use a virtualenv to run tutor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,10 @@ jobs:
     env:
       SSH: ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=150 -i ~/.ssh/demo.key ubuntu@sumac.demo.edly.io
       VERSION: sumac
-      LMS_HOST: sumac.demo.edly.io
-      TUTOR: ~/.local/bin/tutor
+      LMS_HOST: sumac.demo.edly.io$
+      VENV: ~/venv
+      PIP: ~/venv/bin/pip
+      TUTOR: ~/venv/bin/tutor
     steps:
       - name: Configure SSH
         run: |
@@ -24,13 +26,21 @@ jobs:
           chmod 600 ~/.ssh/demo.key
         env:
           SSH_KEY: ${{ secrets.DEMO_SSH_KEY }}
+
+      - name: Create virtualenv
+        run: |
+          $SSH "#! /bin/bash -e
+          rm -rf $VENV
+          python3 -m venv $VENV
+          "
+
       - name: Upgrade python requirements
         # Older versions of pip are affected by this issue which prevents us from
         # installing in editable mode in ~/.local:
         # https://github.com/pypa/pip/issues/7953
         run: |
           $SSH "#! /bin/bash -e
-          pip install --user --upgrade pip setuptools
+          $PIP install --upgrade pip setuptools
           "
       # Server system dependencies, to be run separately
       # apt update && apt install -y python3-pip
@@ -38,21 +48,21 @@ jobs:
         # Pending:
         run: |
           $SSH "#! /bin/bash -e
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor.git@$VERSION#egg=tutor
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-mfe.git@$VERSION#egg=tutor-mfe
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-credentials.git@$VERSION#egg=tutor-credentials
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-minio.git@$VERSION#egg=tutor-minio
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-jupyter.git@$VERSION#egg=tutor-jupyter
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-webui.git@$VERSION#egg=tutor-webui
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/openedx/tutor-contrib-aspects.git@v1.2.0#egg=tutor-contrib-aspects
-            pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor.git@$VERSION#egg=tutor
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-mfe.git@$VERSION#egg=tutor-mfe
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-indigo.git@$VERSION#egg=tutor-indigo
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-discovery.git@$VERSION#egg=tutor-discovery
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-credentials.git@$VERSION#egg=tutor-credentials
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-ecommerce.git@$VERSION#egg=tutor-ecommerce
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-forum.git@$VERSION#egg=tutor-forum
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-minio.git@$VERSION#egg=tutor-minio
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-notes.git@$VERSION#egg=tutor-notes
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-jupyter.git@$VERSION#egg=tutor-jupyter
+            $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-webui.git@$VERSION#egg=tutor-webui
+            $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-aspects.git@v1.2.0#egg=tutor-contrib-aspects
+            $PIP install --upgrade --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
           "
       # Backup
       - name: Backup data


### PR DESCRIPTION
This is necessary because we recently faced the following issue on
plugin install:

	$ pip install --user --upgrade --src=~/apps/openedx/src --editable git+https://github.com/overhangio/tutor-indigo.git@$sumac#egg=tutor-indi09:34:39 [1510/1510]
	error: externally-managed-environment

	× This environment is externally managed
	╰─> To install Python packages system-wide, try apt install
	    python3-xyz, where xyz is the package you are trying to
	    install.

	    If you wish to install a non-Debian-packaged Python package,
	    create a virtual environment using python3 -m venv path/to/venv.
	    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
	    sure you have python3-full installed.

	    If you wish to install a non-Debian packaged Python application,
	    it may be easiest to use pipx install xyz, which will manage a
	    virtual environment for you. Make sure you have pipx installed.

	    See /usr/share/doc/python3.12/README.venv for more information.

	note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or
	OS, by passing --break-system-packages.
	hint: See PEP 668 for the detailed specification.