### PR TITLE
feat: add Scout APM plugin on Axim request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
             $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-webui.git@$VERSION#egg=tutor-webui
             $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-aspects.git@v2.3.0#egg=tutor-contrib-aspects
             $PIP install --upgrade --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
+            $PIP install --upgrade git+https://github.com/openedx/openedx-tutor-plugins.git#subdirectory=plugins/tutor-contrib-scout-apm
           "
       # Backup
       - name: Backup data
@@ -106,7 +107,7 @@ jobs:
       # Configure
       - name: Enable plugins
       # pending plugins: minio
-        run: $SSH "$TUTOR plugins enable indigo mfe aspects codejail credentials discovery notes xqueue android jupyter forum webui"
+        run: $SSH "$TUTOR plugins enable indigo mfe aspects codejail credentials discovery notes xqueue android jupyter forum webui scout-apm"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e
@@ -137,9 +138,16 @@ jobs:
       - name: Configure Aspects
         run: |
           $SSH "$TUTOR config save --set ASPECTS_ENABLE_PII=true --set ASPECTS_ENABLE_STUDIO_IN_CONTEXT_METRICS=true"
+      
+      - name: Configure Scout APM
+        run: |
+          $SSH "$TUTOR config save --set SCOUT_NAME="Edly Teak Sandbox" --set SCOUT_KEY=$SCOUT_APM_KEY
+        env:
+          SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
 
       - name: Launch
         run: $SSH "$TUTOR local launch --non-interactive"
+
       - name: "Provision: Create users"
         run: |
           $SSH "#! /bin/bash -e

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following plugins are enabled on the demo platform:
 - tutor-android ([PR](https://github.com/overhangio/tutor-android/pull/40) by @Abdul-Muqadim-Arbisoft)
   - The mobile apk can be downloaded from https://mobile.teak.demo.edly.io/app.apk.
 - ~~tutor-cairn (TBA)~~
-  - tutor-contrib-aspects ([v2.0.0](https://github.com/openedx/tutor-contrib-aspects/tree/v2.0.0))
+  - tutor-contrib-aspects ([v2.3.0](https://github.com/openedx/tutor-contrib-aspects/tree/v2.3.0))
   - aspects has been enabled in place of cairn for testing of certain Product features.
 - tutor-contrib-codejail ([PR](https://github.com/eduNEXT/tutor-contrib-codejail/pull/68) by @MoisesGSalas)
 - tutor-credentials ([PR](https://github.com/overhangio/tutor-credentials/pull/56) by @mlabeeb03)
@@ -43,6 +43,8 @@ The following plugins are enabled on the demo platform:
 - tutor-xqueue ([PR](https://github.com/overhangio/tutor-xqueue/pull/41) by @jfavellar90)
 - tutor-jupyter ([PR](https://github.com/overhangio/tutor-jupyter/pull/24) by @Abdul-Muqadim-Arbisoft)
   - LTI passport is `jupyterhub:openedx:jupyter-lti-password`.
+- [tutor-contrib-scout-apm](https://github.com/openedx/openedx-tutor-plugins/tree/main/plugins/tutor-contrib-scout-apm)
+  - Scout APM Key has been provided by Axim for Teak Testing
 
 If you are interested in upgrading these plugins to Teak, please submit a PR by following the regular [plugin upgrade instructions](https://discuss.overhang.io/t/how-to-upgrade-a-tutor-plugin/1488).
 


### PR DESCRIPTION
Adds tutor-contrib-scout-apm (https://github.com/openedx/openedx-tutor-plugins/tree/main/plugins/tutor-contrib-scout-apm) on the sandbox on Axim's request (Dave Ormsbee). The secret has been provided by Dave, which has been added as repo secret.