### PR TITLE
Verawood Release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      SSH: ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=150 -i ~/.ssh/demo.key tutor@ulmo.demo.edly.io
-      VERSION: ulmo
-      LMS_HOST: ulmo.demo.edly.io
+      SSH: ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=150 -i ~/.ssh/demo.key tutor@verawood.demo.edly.io
+      VERSION: verawood
+      LMS_HOST: verawood.demo.edly.io
       VENV: ~/venv
       PIP: ~/venv/bin/pip
       TUTOR: ~/venv/bin/tutor
@@ -54,6 +54,8 @@ jobs:
       # apt update && apt install -y python3-pip
       - name: Install dependencies, tutor and plugins (from source)
       # pending:
+        # $PIP install --upgrade --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
+        # $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-notifications.git@$VERSION#egg=tutor-contrib-notifications
         # $PIP install --upgrade git+https://github.com/openedx/openedx-tutor-plugins.git#subdirectory=plugins/tutor-contrib-scout-apm
         run: |
           $SSH "#! /bin/bash -e
@@ -67,9 +69,7 @@ jobs:
             $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-xqueue.git@$VERSION#egg=tutor-xqueue
             $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
             $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-jupyter.git@$VERSION#egg=tutor-jupyter
-            $PIP install --upgrade --editable git+https://github.com/eduNEXT/tutor-contrib-codejail.git@$VERSION#egg=tutor-contrib-codejail
-            $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-aspects.git@ulmo-dev#egg=tutor-contrib-aspects
-            $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-notifications.git@$VERSION#egg=tutor-contrib-notifications
+            $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-aspects.git@$VERSION#egg=tutor-contrib-aspects
           "
       # Backup
       - name: Backup data
@@ -116,8 +116,8 @@ jobs:
           "
       # Configure
       - name: Enable plugins
-      # pending plugins: scout-apm
-        run: $SSH "$TUTOR plugins enable mfe aspects credentials discovery minio forum notes xqueue codejail android jupyter notifications"
+      # pending plugins: codejail notifications scout-apm
+        run: $SSH "$TUTOR plugins enable mfe aspects credentials discovery minio forum notes xqueue android jupyter"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e
@@ -125,7 +125,7 @@ jobs:
               --set LMS_HOST=$LMS_HOST \
               --set CMS_HOST=studio.$LMS_HOST \
               --set ENABLE_HTTPS=true \
-              --set PLATFORM_NAME='Open edX Ulmo Demo'
+              --set PLATFORM_NAME='Open edX Verawood Demo'
           "
 
       - name: Configure xqueue grader password
@@ -152,8 +152,8 @@ jobs:
             $TUTOR images build all
           "
 
-      - name: Initialize codejail
-        run: $SSH "$TUTOR local do init --limit=codejail"
+      # - name: Initialize codejail
+      #   run: $SSH "$TUTOR local do init --limit=codejail"
 
       - name: Launch
         run: $SSH "$TUTOR local launch --skip-build --non-interactive"

--- a/.github/workflows/sync-release-branches.yml
+++ b/.github/workflows/sync-release-branches.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       branch_name:
-        description: 'Release branch to sync (e.g., ulmo)'
+        description: 'Release branch to sync (e.g., verawood)'
         required: true
-        default: 'ulmo'
+        default: 'verawood'
 
 jobs:
   sync-branches:
@@ -44,7 +44,7 @@ jobs:
       
       - name: Check and sync branch
         env:
-          BRANCH: ${{ github.event.inputs.branch_name || 'ulmo' }}
+          BRANCH: ${{ github.event.inputs.branch_name || 'verawood' }}
         run: |
           # Fetch latest changes
           git fetch origin

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Open edX release demo platform CD
 
-This repo holds the continuous deployment (CD) scripts to deploy the Open edX release demo platforms. As of April 24, 2025, it is used to deploy and configure a test instance of the Ulmo release.
+This repo holds the continuous deployment (CD) scripts to deploy the Open edX release demo platforms. As of April 23, 2026, it is used to deploy and configure a test instance of the Verawood release.
 
 ⚠ THIS REPO IS NOT FOR PUBLIC CONSUMPTION ⚠ It is only used to deploy and configure a test instance for the [Build/Test/Release working group](https://discuss.openedx.org/c/working-groups/build-test-release/30). Detected issues should be reported to the working group.
 
 URLs:
 
-- LMS: https://ulmo.demo.edly.io
-- Studio: https://studio.ulmo.demo.edly.io
+- LMS: https://verawood.demo.edly.io
+- Studio: https://studio.verawood.demo.edly.io
 
 You may log in with the following credentials:
 
@@ -26,20 +26,18 @@ The [deployment script](https://github.com/overhangio/openedx-release-demo/blob/
 
 The following plugins are enabled on the demo platform:
 
-- ✅ [tutor-mfe](https://github.com/overhangio/tutor-mfe/tree/ulmo)
-- ✅ [tutor-discovery](https://github.com/overhangio/tutor-discovery/tree/ulmo)
-- ✅ [tutor-credentials](https://github.com/overhangio/tutor-credentials/tree/ulmo)
-- ✅ [tutor-minio](https://github.com/overhangio/tutor-minio/tree/ulmo)
-- ✅ [tutor-forum](https://github.com/overhangio/tutor-forum/tree/ulmo)
-- ✅ [tutor-notes](https://github.com/overhangio/tutor-notes/tree/ulmo)
-- ✅ [tutor-xqueue](https://github.com/overhangio/tutor-xqueue/tree/ulmo)
-- ✅ [tutor-android](https://github.com/overhangio/tutor-android/tree/ulmo)
-- ✅ [tutor-jupyter](https://github.com/overhangio/tutor-jupyter/tree/ulmo)
-- ✅ [tutor-contrib-codejail](https://github.com/eduNEXT/tutor-contrib-codejail/tree/ulmo)
-- ✅ [tutor-contrib-aspects](https://github.com/openedx/tutor-contrib-aspects/tree/ulmo-dev)
-- ✅ [tutor-contrib-notifications](https://github.com/openedx/tutor-contrib-notifications/tree/ulmo)
+- ✅ [tutor-mfe](https://github.com/overhangio/tutor-mfe/pull/291)
+- ✅ [tutor-discovery](https://github.com/overhangio/tutor-discovery/pull/116)
+- ✅ [tutor-credentials](https://github.com/overhangio/tutor-credentials/pull/69)
+- ✅ [tutor-minio](https://github.com/overhangio/tutor-minio/pull/72)
+- ✅ [tutor-forum](https://github.com/overhangio/tutor-forum/pull/75)
+- ✅ [tutor-notes](https://github.com/overhangio/tutor-notes/pull/54)
+- ✅ [tutor-xqueue](https://github.com/overhangio/tutor-xqueue/pull/46)
+- ✅ [tutor-android](https://github.com/overhangio/tutor-android/pull/51)
+- ✅ [tutor-jupyter](https://github.com/overhangio/tutor-jupyter/pull/36)
+- ✅ [tutor-contrib-aspects](https://github.com/openedx/tutor-contrib-aspects/tree/verawood)
 
-If you are interested in upgrading these plugins to Ulmo, please submit a PR by following the regular [plugin upgrade instructions](https://discuss.overhang.io/t/how-to-upgrade-a-tutor-plugin/1488) and mention it in the [sandbox tracking ticket](https://github.com/overhangio/tutor/issues/1281).
+If you are interested in upgrading these plugins to Verawood, please submit a PR by following the regular [plugin upgrade instructions](https://discuss.overhang.io/t/how-to-upgrade-a-tutor-plugin/1488) and mention it in the [sandbox tracking ticket](https://github.com/overhangio/tutor/issues/1370).
 
 ## Testing
 


### PR DESCRIPTION
This PR updates the repository to prepare for the Verawood release sandbox. The following plugins are enabled as of now:

1. mfe
2. aspects
3. credentials
4. discovery
5. minio
6. forum
7. notes
8. xqueue
9. android
10. jupyter

> [!note]
> Indigo, cairn, and deck are not enabled (per the [Verawood tracking issue](https://github.com/overhangio/tutor/issues/1370)). codejail, notifications, and scout-apm are pending.