### PR TITLE
feat: add tutor-portainer plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
             $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-android.git@$VERSION#egg=tutor-android
             $PIP install --upgrade --editable git+https://github.com/overhangio/tutor-jupyter.git@$VERSION#egg=tutor-jupyter
             $PIP install --upgrade --editable git+https://github.com/openedx/tutor-contrib-aspects.git@$VERSION#egg=tutor-contrib-aspects
+            $PIP install --upgrade --editable git+https://github.com/edly-io/tutor-portainer.git#egg=tutor-portainer
           "
       # Backup
       - name: Backup data
@@ -117,7 +118,7 @@ jobs:
       # Configure
       - name: Enable plugins
       # pending plugins: codejail notifications scout-apm
-        run: $SSH "$TUTOR plugins enable mfe aspects credentials discovery minio forum notes xqueue android jupyter"
+        run: $SSH "$TUTOR plugins enable mfe aspects credentials discovery minio forum notes xqueue android jupyter portainer"
       - name: Configure tutor settings
         run: |
           $SSH "#! /bin/bash -e


### PR DESCRIPTION
## Summary
- Install [`tutor-portainer`](https://github.com/edly-io/tutor-portainer) from `edly-io` (master, since the repo has no `verawood` branch) in the `Install dependencies, tutor and plugins` step.
- Enable `portainer` in the `Enable plugins` step so it's brought up on every deploy.

This gives testers a web UI for container logs/stats on the Verawood sandbox, as discussed in #wg-build-test-release.

## Test plan
- [ ] Run the Deploy workflow (manual dispatch is fine).
- [ ] After deploy, browse to `https://portainer.verawood.demo.edly.io` and confirm the Portainer setup screen loads.
- [ ] Create an admin user and confirm the Docker environment is auto-detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)