### PR TITLE
feat: set ENABLE_AUTOMATIC_AUTHZ_COURSE_AUTHORING_MIGRATION to True

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,28 @@ jobs:
         run: |
           $SSH "$TUTOR config save --set ASPECTS_ENABLE_PII=true --set ASPECTS_ENABLE_STUDIO_IN_CONTEXT_METRICS=true"
 
+      - name: Create and enable authz course authoring plugin
+      # Create a Tutor plugin that patches LMS production settings.
+      # It sets ENABLE_AUTOMATIC_AUTHZ_COURSE_AUTHORING_MIGRATION = True,
+      # which enables automatic migration to the new course authoring permissions model
+      # when the "authz.enable_course_authoring" waffle flag is enabled for a course.
+        run: |
+          $SSH "#! /bin/bash -e
+            PLUGIN_ROOT=\$($TUTOR plugins printroot)
+            echo \"Tutor plugin root: \$PLUGIN_ROOT\"
+            mkdir -p \"\$PLUGIN_ROOT\"
+            touch \"\$PLUGIN_ROOT/authz_course_authoring.py\"
+            printf '%s\n' \
+              'from tutor import hooks' \
+              '' \
+              'hooks.Filters.ENV_PATCHES.add_item(' \
+              '    (' \
+              '        \"openedx-lms-production-settings\",' \
+              '        \"ENABLE_AUTOMATIC_AUTHZ_COURSE_AUTHORING_MIGRATION = True\"' \
+              '    )' \
+              ')' > \"\$PLUGIN_ROOT/authz_course_authoring.py\"
+            $TUTOR plugins enable authz_course_authoring
+          "
       # - name: Configure Scout APM
       #   run: |
       #     $SSH "$TUTOR config save --set SCOUT_NAME='Edly Ulmo Sandbox' --set SCOUT_KEY=$SCOUT_APM_KEY"


### PR DESCRIPTION
## Description

I am adding a Django setting `ENABLE_AUTOMATIC_AUTHZ_COURSE_AUTHORING_MIGRATION = True` in the sandbox.

This change enables automatic migration to the new course authoring permissions model when the `"authz.enable_course_authoring"` waffle flag is enabled for a course.

## Related info

- BTR Slack request: https://openedx.slack.com/archives/C049JQZFR5E/p1779803544966079
- ADR about automatic migration: https://github.com/openedx/openedx-authz/blob/main/docs/decisions/0013-course-authoring-automatic-migration.rst#operator-safety-and-opt-in-design
- References in the openedx code: https://github.com/search?q=org%3Aopenedx%20ENABLE_AUTOMATIC_AUTHZ_COURSE_AUTHORING_MIGRATION&type=code (only affects openedx-authz)