### PR TITLE
Persist Portainer data across redeploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,14 @@ jobs:
             else
               echo "No caddy data to backup"
             fi
+            if [ -d ~/.local/share/tutor/env/plugins/portainer/portainer_data ]
+            then
+              echo 'Backing up portainer data'
+              sudo rm -rf ~/apps/openedx/backup/portainer_data
+              sudo cp -r ~/.local/share/tutor/env/plugins/portainer/portainer_data ~/apps/openedx/backup/
+            else
+              echo 'No portainer data to backup'
+            fi
           "
       # Clear
       - name: Clear existing platform
@@ -178,6 +186,19 @@ jobs:
       # - name: Initialize codejail
       #   run: $SSH "$TUTOR local do init --limit=codejail"
 
+      - name: Restore portainer data
+        if: env.CLEAR_DATA == 'true'
+        run: |
+          $SSH "#! /bin/bash -e
+            if [ -d ~/apps/openedx/backup/portainer_data ]
+            then
+              echo 'Restoring portainer data'
+              mkdir -p ~/.local/share/tutor/env/plugins/portainer
+              sudo cp -r ~/apps/openedx/backup/portainer_data ~/.local/share/tutor/env/plugins/portainer/
+            else
+              echo 'No portainer backup data to restore'
+            fi
+          "
       - name: Launch
         run: $SSH "$TUTOR local launch --skip-build --non-interactive"
 


### PR DESCRIPTION
Persist Portainer data across redeploys.

The deploy wipes `~/.local/share/tutor` on every run, destroying the Portainer DB (`env/plugins/portainer/portainer_data`) and losing the admin + all users. This backs it up before the clear and restores it before launch, so Portainer data survives even when `CLEAR_DATA == 'true'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)