### PR TITLE
fix: Unterminated SSH quotes in authz plugin workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,18 +171,24 @@ jobs:
               '    )' \
               ')' > \"\$PLUGIN_ROOT/authz_course_authoring.py\"
             $TUTOR plugins enable authz_course_authoring
+            "
 
       - name: Enable course import in library
         run: |
-          cat > $(tutor plugins printroot)/enable-course-import.yml << 'EOF'
-          name: enable-course-import
-          patches:
-            mfe-lms-production-settings: |
-              MFE_CONFIG["ENABLE_COURSE_IMPORT_IN_LIBRARY"] = True
-          EOF
-          $SSH "tutor plugins enable enable-course-import && tutor config save"
-
+          $SSH "#! /bin/bash -e
+            PLUGIN_ROOT=\$($TUTOR plugins printroot)
+            echo \"Tutor plugin root: \$PLUGIN_ROOT\"
+            mkdir -p \"\$PLUGIN_ROOT\"
+            printf '%s\n' \
+              'name: enable-course-import' \
+              'patches:' \
+              '  mfe-lms-production-settings: |' \
+              '    MFE_CONFIG[\"ENABLE_COURSE_IMPORT_IN_LIBRARY\"] = True' \
+              > \"\$PLUGIN_ROOT/enable-course-import.yml\"
+            $TUTOR plugins enable enable-course-import
+            $TUTOR config save
           "
+
       # - name: Configure Scout APM
       #   run: |
       #     $SSH "$TUTOR config save --set SCOUT_NAME='Edly Ulmo Sandbox' --set SCOUT_KEY=$SCOUT_APM_KEY"


### PR DESCRIPTION
- Fix unterminated SSH quotes in authz plugin workflow
- Update course-import plugin step over SSH so it lands on the remote host